### PR TITLE
本と羽根ペンのアイテム名が特定の条件下で消失する不具合の修正

### DIFF
--- a/plugin/src/main/java/de/epiceric/shopchest/language/item/LocalizedItemNameManager.java
+++ b/plugin/src/main/java/de/epiceric/shopchest/language/item/LocalizedItemNameManager.java
@@ -52,7 +52,10 @@ public class LocalizedItemNameManager implements ItemNameManager {
         }
 
         if (meta instanceof BookMeta) {
-            return ((BookMeta) meta).getTitle();
+            final String bookTitle = ((BookMeta) meta).getTitle();
+            if(bookTitle!=null && !bookTitle.isEmpty()){
+                return bookTitle;
+            }
         }
 
         if (meta instanceof SkullMeta) {

--- a/plugin/src/main/java/de/epiceric/shopchest/language/item/LocalizedItemNameManager.java
+++ b/plugin/src/main/java/de/epiceric/shopchest/language/item/LocalizedItemNameManager.java
@@ -53,7 +53,7 @@ public class LocalizedItemNameManager implements ItemNameManager {
 
         if (meta instanceof BookMeta) {
             final String bookTitle = ((BookMeta) meta).getTitle();
-            if(bookTitle!=null && !bookTitle.isEmpty()){
+            if (bookTitle != null && !bookTitle.isEmpty()) {
                 return bookTitle;
             }
         }


### PR DESCRIPTION
以下の変更を含みます
- 本のタイトルが空でないかの評価を追加 9bf235e